### PR TITLE
Resize blog title header for mobile

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -9,22 +9,7 @@ class Layout extends React.Component {
     let header
 
     if (title !== undefined) {
-      header = (
-        <h1
-          style={{
-            font: `400 70px Oswald`,
-            letterSpacing: `6px`,
-            wordSpacing: `9px`,
-            marginBottom: rhythm(1.5),
-            marginTop: 0,
-            textTransform: `uppercase`,
-            textDecoration: `none`,
-            textAlign: `center`,
-          }}
-        >
-          {title}
-        </h1>
-      )
+      header = <h1 className="blog-header">{title}</h1>
     }
     return (
       <div

--- a/src/styles/text.css
+++ b/src/styles/text.css
@@ -7,6 +7,40 @@ h6 {
   font-family: "PT Sans";
 }
 
+.blog-header {
+  font: 400 70px Oswald;
+  letter-spacing: 6px;
+  word-spacing: 9px;
+  text-transform: uppercase;
+  text-decoration: none;
+  text-align: center;
+  margin-top: 0;
+}
+
+@media screen and (max-width: 600px) {
+  .blog-header {
+    font: 400 50px Oswald;
+    letter-spacing: 4px;
+    word-spacing: 6px;
+  }
+}
+
+@media screen and (max-width: 450px) {
+  .blog-header {
+    font: 400 40px Oswald;
+    letter-spacing: 4px;
+    word-spacing: 6px;
+  }
+}
+
+@media screen and (max-width: 365px) {
+  .blog-header {
+    font: 400 30px Oswald;
+    letter-spacing: 3px;
+    word-spacing: 4px;
+  }
+}
+
 p {
   margin-top: 1.2em;
   margin-bottom: 1.2em;


### PR DESCRIPTION
Shrink the size of the header as the screen size decreases.
This means that the header does not take up a large amount of
space on mobile. It also improves the experience on browsers
when then browser size is reduced.