### PR TITLE
Improve contrast on blog cards and tags

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -262,7 +262,7 @@ module.exports = {
         short_name: `lankydan.dev`,
         start_url: `/`,
         background_color: `#ffffff`,
-        theme_color: `#663399`,
+        theme_color: `#613380`,
         display: `minimal-ui`,
         icon: `content/assets/logo.svg`,
       },

--- a/src/components/blog-tag.js
+++ b/src/components/blog-tag.js
@@ -4,16 +4,20 @@ export default class BlogTag extends React.Component {
   render() {
     const { name } = this.props
     const { backgroundColor, color } = this.getTagColorScheme(name)
+    const style = {
+      display: `inline-block`,
+      marginRight: `2px`,
+      padding: `0px 8px`,
+      borderRadius: `4px`,
+    }
+    if(backgroundColor != null && color != null) {
+      style.backgroundColor = backgroundColor
+      style.color = color
+    }
     return (
       <small
-        style={{
-          backgroundColor: backgroundColor,
-          color: color,
-          display: `inline-block`,
-          marginRight: `2px`,
-          padding: `0px 8px`,
-          borderRadius: `4px`,
-        }}
+        className="blog-tag"
+        style={style}
       >
         {name}
       </small>
@@ -21,13 +25,13 @@ export default class BlogTag extends React.Component {
   }
 
   getTagColorScheme(name) {
-    if(name.includes(`spring`)) {
+    if (name.includes(`spring`)) {
       return {
-        backgroundColor: `#6db33f`,
+        backgroundColor: `#2E7D32`,
         color: `white`,
       }
     }
-    if(name.includes(`corda`)) {
+    if (name.includes(`corda`)) {
       return {
         backgroundColor: `#e11c1b`,
         color: `white`,
@@ -37,28 +41,28 @@ export default class BlogTag extends React.Component {
       case `java`:
         return {
           backgroundColor: `#292D3E`,
-          color: `#82AAFF`,
+          color: `white`,
         }
       case `kotlin`:
         return {
-          backgroundColor: `#5f77df`,
-          color: `#ffa032`,
+          backgroundColor: `#4258b8`,
+          color: `white`,
         }
       case `cassandra`:
         return {
-          backgroundColor: `#36f7ba`,
-          color: `#5824db`,
+          backgroundColor: `#880E4F`,
+          color: `white`,
         }
       case `dlt`:
       case `distributed ledger technology`:
         return {
-          backgroundColor: `#ff6f16`,
-          color: `#2439de`,
+          backgroundColor: `#4A148C`,
+          color: `white`,
         }
       case `blockchain`:
         return {
-          backgroundColor: `#55d5f5`,
-          color: `#ba40db`,
+          backgroundColor: `#C2185B`,
+          color: `white`,
         }
       case `docker`:
         return {
@@ -72,8 +76,8 @@ export default class BlogTag extends React.Component {
         }
       default:
         return {
-          backgroundColor: `rgba(97, 51, 128, 0.612)`,
-          color: `white`,
+          backgroundColor: null,
+          color: null,
         }
     }
   }

--- a/src/styles/blog-card.css
+++ b/src/styles/blog-card.css
@@ -50,9 +50,14 @@ div .blog-card-title {
 }
 
 div small {
-  color: var(--secondary-color-medium);
+  color: var(--font-color);
 }
 
 div p {
   color: var(--font-color);
+}
+
+small.blog-tag {
+  color: white;
+  background-color: var(--primary-color)
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -4,7 +4,6 @@
   --primary-color-dark: #613380;
   --secondary-color: #ffffff;
   --secondary-color-light: #4a4a4a;
-  --secondary-color-medium: grey;
   --font-color: #000000cc;
   --bg-color: #ffffff;
   --code-bg-color: #272c34;
@@ -21,7 +20,6 @@
   --primary-color-dark: #7f348f;
   --secondary-color: #50555e;
   --secondary-color-light: #ccd2dd;
-  --secondary-color-medium: #aeb3bd;
   --font-color: #ccd2dd;
   --bg-color: #282c34;
   --code-bg-color: #23262c;
@@ -35,4 +33,8 @@
 body {
   background-color: var(--bg-color);
   color: var(--font-color);
+}
+
+:focus {
+  outline-color: var(--primary-color)
 }


### PR DESCRIPTION
Improve contrast by:

- Use font color for dates on blog cards
- Use material color pallete on blog tags
- Change default blog tag color to theme primary color