### PR TITLE
Remove Disqus comments from blog

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,6 @@ module.exports = {
     author: `Dan Newton`,
     description: `Lanky Dan - Software Development Blog`,
     siteUrl: `https://lankydan.dev`,
-    disqusShortName: `lankydan-dev`,
     social: {
       twitter: `LankyDanDev`,
       linkedin: `https://www.linkedin.com/in/danknewton/`,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@types/react": "^16.9.19",
-    "disqus-react": "^1.0.7",
     "gatsby": "^2.19.12",
     "gatsby-image": "^2.2.40",
     "gatsby-plugin-feed": "^2.3.27",

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -11,7 +11,6 @@ import BlogList from "../components/blog-list"
 import BlogTags from "../components/blog-tags"
 import BlogSeries from "../components/blog-series"
 import BlogPostDate from "../components/blog-post-date"
-import Disqus from "disqus-react"
 import urljoin from "url-join"
 
 class BlogPostTemplate extends React.Component {
@@ -25,11 +24,6 @@ class BlogPostTemplate extends React.Component {
       this.props.data.site.siteMetadata.siteUrl,
       this.props.pageContext.slug
     )
-    const disqusConfig = {
-      url: postUrl,
-      identifier: this.props.pageContext.slug,
-      title: post.frontmatter.title,
-    }
     return (
       <Layout location={this.props.location}>
         <SEO
@@ -115,10 +109,6 @@ class BlogPostTemplate extends React.Component {
             marginBottom: rhythm(1),
           }}
         />
-        <Disqus.DiscussionEmbed
-          shortname={this.props.data.site.siteMetadata.disqusShortName}
-          config={disqusConfig}
-        />
         <BlogList
           posts={posts}
           cardWidth={rhythm(15)}
@@ -164,7 +154,6 @@ export const pageQuery = graphql`
         title
         author
         siteUrl
-        disqusShortName
       }
     }
     markdownRemark(fields: { slug: { eq: $slug } }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3979,11 +3979,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-disqus-react@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/disqus-react/-/disqus-react-1.0.7.tgz#61061d3b6237b956baa9c5d96780fd311cdbecfc"
-  integrity sha512-7sPHIauS5mUxkZtGtik/ELZ38kOGH3N+YFNt7U4ncczNdAVmWNmAetDE+dHYnrL1Xx+Pgueh1uKpvfUIeu7WuQ==
-
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"


### PR DESCRIPTION
Disqus was slowing down the loading of blog posts. It was making a high
amount of requests including ads.

There are alternatives to Disqus but I think it is easier to not have
them at all. I don't get that many comments anyway.

It might be possible to link the post to other social media to replace
the use of comments.