### PR TITLE
Use CSS Grid for blog list

### DIFF
--- a/src/components/blog-list.js
+++ b/src/components/blog-list.js
@@ -6,9 +6,10 @@ import BlogTags from "./blog-tags"
 
 class BlogList extends React.Component {
   render() {
-    const { posts, cardWidth, cardHeight } = this.props
+    const { posts, cardWidth, cardHeight, isFooter } = this.props
+    const className = isFooter ? "blog-card-list footer-blog-list" : "blog-card-list"
     return (
-      <div className="blog-card-list">
+      <div className={className}>
         {posts.map(({ node }) => {
           const title = node.frontmatter.title || node.fields.slug
           return (

--- a/src/components/footer-blog-list.js
+++ b/src/components/footer-blog-list.js
@@ -1,0 +1,19 @@
+import React from "react"
+import { rhythm } from "../utils/typography"
+import BlogList from "../components/blog-list"
+
+class FooterBlogList extends React.Component {
+  render() {
+    const { posts } = this.props
+    return (
+      <BlogList
+        isFooter={true}
+        posts={posts}
+        cardWidth={rhythm(15)}
+        cardHeight={rhythm(12.5)}
+      />
+    )
+  }
+}
+
+export default FooterBlogList

--- a/src/styles/blog-card.css
+++ b/src/styles/blog-card.css
@@ -1,28 +1,38 @@
-div .blog-card-list {
-  max-width: 100%;
-  margin: 0 auto;
-  float: none;
-  text-align: center;
-  display: block;
+.blog-card-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(40%, 1fr));
+  grid-template-rows: repeat(5, minmax(10%, 1fr));
+  grid-gap: 1.5rem;
+}
+
+.footer-blog-list {
+  grid-template-rows: repeat(2, minmax(10%, 1fr));
+  margin: 0 10% 0 10%;
+  padding-bottom: 2rem;
+}
+
+@media screen and (max-width: 1000px) {
+  .blog-card-list {
+    grid-template-columns: repeat(1, minmax(90%, 1fr));
+    grid-template-rows: repeat(10, minmax(5%, 1fr));
+    grid-gap: 1rem;
+  }
+
+  .footer-blog-list {
+    grid-template-rows: repeat(4, minmax(10%, 1fr));
+    margin: 0 5% 0 5%;
+  }
 }
 
 a.blog-card-link {
   box-shadow: none;
-  display: inline-block;
   max-width: 100%;
-  padding: 10px;
-  vertical-align: top;
-  text-align: left;
-  float: none;
-  position: relative;
   margin: 0 auto;
   background-image: none;
 }
 
 div .blog-card {
   box-shadow: 6px 9px 4px 0px #00000099;
-  margin: 0.5em 0px 0px;
-  max-width: 100%;
   border-radius: 10px;
   background-color: var(--secondary-color);
 }
@@ -33,14 +43,14 @@ div .blog-card-text {
   border-style: solid;
   border-radius: 0px 0px 10px 10px;
   border-color: var(--blog-card-border-color);
+  min-height: 15rem;
+}
+
+div .blog-card-text p {
+  margin-bottom: 0px;
 }
 
 div .blog-card img {
-  position: relative;
-  width: 100%;
-  margin: auto;
-  background: transparent no-repeat center center;
-  background-size: cover;
   z-index: 2;
   border-radius: 10px 10px 0px 0px;
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -7,7 +7,7 @@ import SEO from "../components/seo"
 import { rhythm } from "../utils/typography"
 import Img from "gatsby-image"
 import Socials from "../components/socials"
-import BlogList from "../components/blog-list"
+import FooterBlogList from "../components/footer-blog-list"
 import BlogTags from "../components/blog-tags"
 import BlogSeries from "../components/blog-series"
 import BlogPostDate from "../components/blog-post-date"
@@ -16,7 +16,7 @@ import urljoin from "url-join"
 class BlogPostTemplate extends React.Component {
   render() {
     const post = this.props.data.markdownRemark
-    const posts = this.props.data.lastFivePosts.edges
+    const posts = this.props.data.lastFourPosts.edges
     const series = this.props.data.series.edges
     const githubUrl = post.frontmatter.github_url
     const { previous, next } = this.props.pageContext
@@ -109,11 +109,7 @@ class BlogPostTemplate extends React.Component {
             marginBottom: rhythm(1),
           }}
         />
-        <BlogList
-          posts={posts}
-          cardWidth={rhythm(15)}
-          cardHeight={rhythm(12.5)}
-        />
+        <FooterBlogList posts={posts}/>
         <div>
           <ul
             style={{
@@ -201,13 +197,13 @@ export const pageQuery = graphql`
         }
       }
     }
-    lastFivePosts: allMarkdownRemark(
+    lastFourPosts: allMarkdownRemark(
       sort: { fields: [frontmatter___date], order: DESC }
       filter: {
         fields: { slug: { ne: $slug } }
         frontmatter: { published: { eq: true } }
       }
-      limit: 5
+      limit: 4
     ) {
       edges {
         node {


### PR DESCRIPTION
Use CSS Grid for blog list display instead of custom CSS that I put
together. The blog cards now properly form a grid rather than changing
size depending on their content.

Once this was done, I was able to remove a lot of CSS that was no
longer needed.